### PR TITLE
Force execution of subprocess, and close fds

### DIFF
--- a/phantom_pdf/generator.py
+++ b/phantom_pdf/generator.py
@@ -124,13 +124,14 @@ class RequestToPDF(object):
         domain = urlparse.urlsplit(
             request.build_absolute_uri()
         ).netloc.split(':')[0]
-        Popen([
+        phandle = Popen([
             self.PHANTOMJS_BIN,
             self.PHANTOMJS_GENERATE_PDF,
             url,
             file_src,
             cookie_file,
-            domain], stdout=PIPE, stderr=STDOUT)
+            domain], close_fds=True, stdout=PIPE, stderr=STDOUT)
+        phandle.communicate()
 
         # Once the pdf is created, remove the cookie file.
         os.remove(cookie_file)


### PR DESCRIPTION
This addresses issue #1. I'm not sure if it is ideal, as it may cause issues on windows, but it works fine for my use-cases. See the comments about close_fds and windows on the subprocess documentation: https://docs.python.org/2/library/subprocess.html#popen-constructor
