### PR TITLE
Fixed an issue while trying to read a temp generated PDF file and returning it.

### DIFF
--- a/phantom_pdf/generator.py
+++ b/phantom_pdf/generator.py
@@ -95,16 +95,14 @@ class RequestToPDF(object):
 
     def _return_response(self, file_src, basename):
         """Read the generated pdf and return it in a django HttpResponse."""
-        try:
-            # Open the file created by PhantomJS
-            return_file = open(file_src, 'r')
-        except IOError:
-            exc_msg = "The PDF was not created. Enable debug at RequestToPDF instance."
-            raise Exception(exc_msg)
+        # Open the file created by PhantomJS
+        return_file = None
+        with open(file_src, 'rb') as f:
+            return_file = f.readlines()
 
         response = HttpResponse(
             return_file,
-            mimetype='application/force-download'
+            content_type='application/pdf'
         )
         content_disposition = 'attachment; filename=%s.pdf' % (basename)
         response['Content-Disposition'] = content_disposition


### PR DESCRIPTION
- Al momento de leer el archivo PDF generado de manera temporal el modo de lectura no incluía el flag "b" (binary) por lo cual, luego de descargar dicho archivo, resultaba totalmente ilegible para el lector PDF.
- Django 1.6.5 recomienda utilizar `content_type` en lugar de `mimetype` como configuración de un `HttpResponse`
- La [documentación de Django](https://docs.djangoproject.com/en/1.6/howto/outputting-pdf/) sugiere utilizar el header `Content-Type` definido como `application/pdf`
