### PR TITLE
changed generator.py to allow internal dispatching

### DIFF
--- a/phantom_pdf/generator.py
+++ b/phantom_pdf/generator.py
@@ -84,7 +84,7 @@ class RequestToPDF(object):
         domain = netloc
         return '{protocol}://{domain}{path}'.format(
             protocol=protocol,
-            domain=domain,
+            domain=getattr(settings, 'PHANTOMJS_DOMAIN', domain),
             path=path)
 
     def _save_cookie_data(self, request):


### PR DESCRIPTION
It would be convenient to be able to set the domain via settings so we can set it to localhost for example. This makes sure we can dispatch calls to the pdf from the system instead of going outside, e.g. through load balancers or reverse proxies (if any).
